### PR TITLE
removed unused variable

### DIFF
--- a/lib/FeaturePopups.js
+++ b/lib/FeaturePopups.js
@@ -2406,7 +2406,6 @@ OpenLayers.Control.FeaturePopups.Layer = OpenLayers.Class({
      * feature - {OpenLayers.Feature.Vector} Feature to store as selected.
      */
     storeAsSelected: function(feature) {
-        var layerId = feature.layer.id;
         var savedSF = this.selection;
         if (feature.cluster) {
             for (var i = 0 , len = feature.cluster.length; i < len; i++) {


### PR DESCRIPTION
Unused param might cause a problem if the feature is a cluster without a layer id. Removing it solves potential problems when implementing onFeatureSelected events.
